### PR TITLE
[Security] do not expose passwords

### DIFF
--- a/js/credential_storage.js
+++ b/js/credential_storage.js
@@ -109,6 +109,5 @@ module.exports = function() {
         'removeCredential': removeCredential,
         'clearAll': clearAll,
         'addCredential': addCredential,
-        'asJSON': function() { return JSON.stringify(credentials); },
     };
 }();

--- a/js/credentials.js
+++ b/js/credentials.js
@@ -6,7 +6,6 @@ var Translator = require('./translator');
 
 module.exports = function() {
     var password_stars_class = 'password-stars';
-    var password_real_class = 'password-real';
 
     var storage_key = 'temporary-credentials';
 
@@ -52,8 +51,6 @@ module.exports = function() {
                         '<td class="username" title="' + c.username + '">' + c.username + '</td>' +
                         '<td class="password">' +
                             '<span class="' + password_stars_class + '">***</span>' +
-                            '<span class="' + password_real_class + '">' + c.password + '</span>' +
-                            '<button class="show-password">' + Translator.translate('show_hide_password') + '</button>' +
                         '</td>' +
                         '<td class="priority">' + (c.priority || 1) + '</td>' +
                         '<td class="action">' +
@@ -63,16 +60,6 @@ module.exports = function() {
                     '</tr>';
             }
         }
-    }
-
-    function togglePassword(e) {
-        var password = e.target.parentNode;
-        var star = password.getElementsByClassName(password_stars_class)[0];
-        var real = password.getElementsByClassName(password_real_class)[0];
-
-        var password_shown = star.style.display == 'none';
-        star.style.display = password_shown ? 'inline' : 'none';
-        real.style.display = password_shown ? 'none' : 'inline';
     }
 
     function submit(e) {
@@ -137,7 +124,7 @@ module.exports = function() {
 
         url.value = tr.getElementsByClassName('url')[0].textContent;
         username.value = tr.getElementsByClassName('username')[0].textContent;
-        password.value = tr.getElementsByClassName('password-real')[0].textContent;
+        password.value = '';  // use sha hash to check if password was changed
         priority.value = tr.getElementsByClassName('priority')[0].textContent;
 
         document.getElementsByClassName('credential-form-submit')[0].textContent = Translator.translate('edit_credential');
@@ -167,10 +154,6 @@ module.exports = function() {
             if(e.target.matches('.edit')) {
                 e.stopPropagation();
                 edit(e);
-            }
-            if(e.target.matches('.show-password')) {
-                e.stopPropagation();
-                togglePassword(e);
             }
         });
 

--- a/js/option.js
+++ b/js/option.js
@@ -142,11 +142,6 @@ var OptionPanel = function() {
         });
     }
 
-    function export_credentials(e) {
-        var data = 'text/json;charset=utf-8,' + encodeURIComponent(CredentialStorage.asJSON());
-        e.target.setAttribute('href', 'data:' + data);
-    }
-
     function clear_credentials(e) {
         modal(Translator.translate('clear_credentials_modal_title'), Translator.translate('clear_credentials_modal_text'), CredentialStorage.clearAll);
         e.preventDefault();
@@ -164,8 +159,6 @@ var OptionPanel = function() {
         document.getElementById('test-urls').addEventListener('blur', restore_test_input);
         document.getElementById('test-urls').addEventListener('keyup', test_regex);
         document.getElementById('test-regex').addEventListener('keyup', test_regex);
-
-        document.querySelector('a.export-credentials').addEventListener('click', export_credentials);
 
         document.querySelector('button.clear-all').addEventListener('click', clear_credentials);
 

--- a/options.html
+++ b/options.html
@@ -120,10 +120,6 @@
                 </table>
             </form>
 
-            <h2 data-i18n="export_section">Export</h2>
-
-            <p><a href="#" download="multipass-credentials.json" class="export-credentials" data-i18n="export_button">Download credentials as JSON file.</a></p>
-
             <h2 data-i18n="clear_section">Clear all credentials</h2>
 
             <button class="clear-all" data-i18n="clear_button">Clear all credentials</button>


### PR DESCRIPTION
Once browser remains unattended even for a some minutes,
passwords could be hi-jacked using `show/hide` or `export` functionality, or even via dev-tools console `$('#password').value` by inspecting popin.html.

~Also this PR provides:~
~- [doc] install packages from lock file using `npm ci`~
~- [doc] note on how to build using `docker` - using node v12, as higher version requires complex review~
~- [deps] update `gulp` and its tasks to version `4` - number of compilation failures with version `3`~
~- [deps] update minor versions using `npm audit fix`~

UPD: doc and deps off-loaded into #84